### PR TITLE
Fix #3; allow to set certname

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ On Ubuntu 12.04 and Debian 6 the last available package is from Puppet 4 series.
 
 Download this script (read it before!) and run it in the host, as root:
 
-    # curl https://raw.githubusercontent.com/instruct-br/puppet-installer/master/installer.sh | bash -s
+    # curl -s https://raw.githubusercontent.com/instruct-br/puppet-installer/master/installer.sh | bash -s [certname]
 
-The script will use the hostname and domain for the certificate name.
+The script will use the first parameter as the certificate name, if available, or the value from `certname` environment variable, if defined. The env variable have precedence, if both values are defined, and the script will fail if the `certname` is not defined.
 
 Some environment variables can be declared so the script will consider them during the install. This is the list:
 
@@ -27,6 +27,7 @@ Some environment variables can be declared so the script will consider them duri
 - `port`: configure the Puppet Server (and CA) port to connect. Defaults to *8140*;
 - `ca_server`: configure the Puppet Server CA to sign the certificate. Defaults to `puppet`;
 - `environment`: configure the environment the catalog will come from. Defaults to `production`.
+- `certname`: configure the host certname. This value has precedence over the command line parameter.
 
 The suggestion is to export the expected values, so the script will use them:
 

--- a/installer.sh
+++ b/installer.sh
@@ -8,6 +8,9 @@ PUPPET_SERVER=${puppet:-'puppet'}                 # Puppet Server host
 PUPPET_SERVER_PORT=${port:-'8140'}                # Puppet Server port
 PUPPET_SERVER_CA=${ca_server:-'puppet'}           # Puppet CA Server host
 PUPPET_ENVIRONMENT=${environment:-'production'}   # Puppet environment
+PUPPET_CERTNAME=${certname:-$1}
+
+: "${PUPPET_CERTNAME?"Usage: $0 certname"} "
 
 LOGDIR="/var/log"                                 # logs folder
 LOCKFILE="/tmp/puppet.installer.lock"             # lock file
@@ -29,6 +32,7 @@ check_bash() {
     echo "Puppet Server: ${PUPPET_SERVER}"
     echo "Puppet Server port: ${PUPPET_SERVER_PORT}"
     echo "Puppet Server environment: ${PUPPET_ENVIRONMENT}"
+    echo "Puppet certname: ${PUPPET_CERTNAME}"
     echo "===== ===== ====="
   fi
 }
@@ -343,11 +347,12 @@ config_puppet_conf() {
   log "Configuring puppet.conf file"
   cat << EOF > /etc/puppetlabs/puppet/puppet.conf
 [main]
-    ca_server         = ${PUPPET_SERVER_CA}
-    server            = ${PUPPET_SERVER}
-    port              = ${PUPPET_SERVER_PORT}
+    ca_server = ${PUPPET_SERVER_CA}
+    server    = ${PUPPET_SERVER}
+    port      = ${PUPPET_SERVER_PORT}
 [agent]
-    environment       = ${PUPPET_ENVIRONMENT}
+    environment = ${PUPPET_ENVIRONMENT}
+    certname    = ${PUPPET_CERTNAME}
 EOF
 }
 


### PR DESCRIPTION
This change will demand the agent certname to be defined, using the first
parameter to the script. If the parameter is not set the script will
fail.