### PR TITLE
Fix #5; add support to Windows agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puppet Installer
 
-This project contains a BASH script to install Puppet Agent.
+This project contains a BASH script to install Puppet Agent on Linux machines, and a PowerShell script to install it on Windows machines.
 
 ## Compatibility
 
@@ -10,10 +10,13 @@ The script was tested on these operating systems:
 - Debian 6, 7, 8, and 9
 - Ubuntu 12.04, 14.04, 16.04 and 18.04
 - SLES 11 and 12
+- Windows 2008, 2012 e 2016
 
 On Ubuntu 12.04 and Debian 6 the last available package is from Puppet 4 series. All others OSes can use Puppet 5 versions.
 
 ## Using
+
+### On Linux hosts
 
 Download this script (read it before!) and run it in the host, as root:
 
@@ -36,3 +39,20 @@ The suggestion is to export the expected values, so the script will use them:
 To enable a debug while running the script it is also possible to export the variable DEBUG, with any content:
 
     # export DEBUG=true
+
+### On Windows hosts
+
+Download this script from this URL:
+
+    https://raw.githubusercontent.com/instruct-br/puppet-installer/master/installer.ps1
+
+Then run it like this, as administrator:
+
+    c:\> powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "& '.\installer.ps1'"
+
+Some variables can be declared so the script will consider them during the install. This is the list:
+
+- `PuppetServer`: configure the Puppet Server to provide the catalogs. Defaults to `puppet`;
+- `PuppetCAServer`: configure the Puppet Server CA to sign the certificate. Defaults to `puppet`;
+- `PuppetEnvironment`: configure the environment the catalog will come from. Defaults to `production`.
+- `PuppetCertname`: configure the host certname. This value is obligatory, and will be prompted if not specified.

--- a/installer.ps1
+++ b/installer.ps1
@@ -1,0 +1,108 @@
+<#
+Originally developed by Hashicorp.
+Source: https://raw.githubusercontent.com/hashicorp/puppet-bootstrap/master/windows.ps1
+
+.SYNOPSIS
+    Installs Puppet on this machine.
+
+.DESCRIPTION
+    Downloads and installs the official Puppet MSI package.
+
+    This script requires administrative privileges.
+
+    You can run this script from an old-style cmd.exe prompt using the
+    following:
+
+      powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "& '.\installer.ps1'"
+
+.PARAMETER MsiUrl
+    This is the URL to the Puppet MSI file you want to install. This defaults
+    to latest version from Puppet 5.
+
+.PARAMETER PuppetCAServer
+    This is the name of Puppet Server CA that will sign the agent keys.
+    This defaults to 'puppet'.
+
+.PARAMETER PuppetCertname
+    This is the name Puppet agent will present itself to the Server.
+
+.PARAMETER PuppetEnvironment
+    This is the name of the Puppet environment the catalog will come from.
+    This defaults to 'production'.
+
+.PARAMETER PuppetServer
+    This is the name of Puppet Server that will provide the catalogs.
+    This defaults to 'puppet'.
+
+.PARAMETER PuppetVersion
+    This is the version of Puppet that you want to install. If you pass this it will override the version in the MsiUrl.
+    This defaults to $null.
+#>
+param(
+    [string]$MsiUrl = "https://downloads.puppet.com/windows/puppet5/puppet-agent-x64-latest.msi",
+    [string]$PuppetCAServer = "puppet",
+
+    [Parameter(
+        Mandatory=$True,
+        HelpMessage="Enter the Puppet agent certname"
+    )]
+    [string]$PuppetCertname = $null,
+    [string]$PuppetEnvironment = "production",
+    [string]$PuppetServer = "puppet",
+    [string]$PuppetVersion = $null
+)
+
+if ($PuppetVersion) {
+    $MsiUrl = "https://downloads.puppet.com/windows/puppet5/puppet-agent-$($PuppetVersion)-x64.msi"
+    Write-Output "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
+}
+
+$PuppetInstalled = $false
+try {
+    $ErrorActionPreference = "Stop";
+    Get-Command puppet | Out-Null
+    $PuppetInstalled = $true
+    $PuppetVersion = &puppet "--version"
+    Write-Output "Puppet $PuppetVersion is installed. This process does not ensure the exact version or at least version specified, but only that puppet is installed. Exiting..."
+    Exit 0
+} catch {
+    Write-Output "Puppet is not installed, continuing..."
+}
+
+if (!($PuppetInstalled)) {
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    if (! ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+        Write-Output -ForegroundColor Red "You must run this script as an administrator."
+        Exit 1
+    }
+
+    # Install it - msiexec will download from the url
+    $install_args = @(
+        "/qn",
+        "/norestart",
+        "/i",
+        $MsiUrl,
+        "PUPPET_MASTER_SERVER=$PuppetServer",
+        "PUPPET_CA_SERVER=$PuppetCAServer",
+        "PUPPET_AGENT_ENVIRONMENT=$PuppetEnvironment"
+    )
+
+    if ($PuppetCertname) {
+        Write-Output "Configuring certname as $PuppetCertname"
+        $install_args += "PUPPET_AGENT_CERTNAME=$($PuppetCertname)"
+    }
+
+    Write-Output "Installing Puppet. Running msiexec.exe $install_args"
+    $process = Start-Process -FilePath msiexec.exe -ArgumentList $install_args -Wait -PassThru
+    if ($process.ExitCode -ne 0) {
+        Write-Output "Installer failed."
+        Exit 1
+    }
+
+    # Stop the service that it autostarts
+    Write-Output "Stopping Puppet service that is running by default..."
+    Start-Sleep -s 5
+    Stop-Service -Name puppet
+
+    Write-Output "Puppet successfully installed."
+}


### PR DESCRIPTION
This changes includes a PowerShell script to install the Puppet Agent on
Windows hosts.